### PR TITLE
Fix GitHub Pages deployment .nojekyll file creation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,8 +44,27 @@ jobs:
       env:
         NODE_ENV: production
         
-    - name: Add .nojekyll file
-      run: touch out/.nojekyll
+    - name: Verify build output and add .nojekyll file
+      run: |
+        if [ ! -d "out" ]; then
+          echo "Error: Build output directory 'out' not found!"
+          echo "Current directory contents:"
+          ls -la
+          exit 1
+        fi
+        echo "Build output directory verified"
+        echo "Adding .nojekyll file for GitHub Pages compatibility..."
+        touch out/.nojekyll
+        
+        if [ ! -f "out/.nojekyll" ]; then
+          echo "Error: Failed to create .nojekyll file!"
+          exit 1
+        fi
+        
+        echo "✓ .nojekyll file created successfully"
+        echo "Final verification - checking critical files:"
+        echo "- index.html: $([ -f "out/index.html" ] && echo "✓ exists" || echo "✗ missing")"
+        echo "- .nojekyll: $([ -f "out/.nojekyll" ] && echo "✓ exists" || echo "✗ missing")"
       
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
Enhanced the GitHub Actions deployment workflow to properly handle .nojekyll file creation for GitHub Pages with comprehensive error handling and verification.

## Problem
The existing deployment workflow had a basic `.nojekyll` file creation step but lacked proper error handling and verification, which could lead to silent failures during the CI/CD process.

## Solution
- **Enhanced verification**: Added explicit checks for build output directory existence with detailed error reporting
- **Improved .nojekyll handling**: Added verification that the .nojekyll file is successfully created
- **Better error handling**: Added clear error messages and exit codes for debugging failed deployments
- **Final verification**: Added checks for critical files before deployment

## Changes Made
```yaml
# Before
- name: Add .nojekyll file
  run: touch out/.nojekyll

# After  
- name: Verify build output and add .nojekyll file
  run: |
    if [ \! -d "out" ]; then
      echo "Error: Build output directory 'out' not found\!"
      echo "Current directory contents:"
      ls -la
      exit 1
    fi
    echo "Build output directory verified"
    echo "Adding .nojekyll file for GitHub Pages compatibility..."
    touch out/.nojekyll
    
    if [ \! -f "out/.nojekyll" ]; then
      echo "Error: Failed to create .nojekyll file\!"
      exit 1
    fi
    
    echo "✓ .nojekyll file created successfully"
    echo "Final verification - checking critical files:"
    echo "- index.html: $([ -f "out/index.html" ] && echo "✓ exists" || echo "✗ missing")"
    echo "- .nojekyll: $([ -f "out/.nojekyll" ] && echo "✓ exists" || echo "✗ missing")"
```

## Test Verification
- [x] Verified local build process creates `out` directory correctly
- [x] Tested enhanced workflow steps locally
- [x] Confirmed error handling provides clear feedback on failures

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)