### PR TITLE
Fix FilterSidepanel height layout - ensure full viewport height

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,8 +52,8 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
-      <div className="flex">
+    <div className="h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <div className="flex h-full">
         {/* Filter Sidepanel */}
         <FilterSidepanel
           filters={filters}
@@ -64,7 +64,7 @@ export default function Home() {
         />
         
         {/* Main Content */}
-        <div className="flex-1 lg:ml-0">
+        <div className="flex-1 lg:ml-0 overflow-y-auto">
           <div className="container mx-auto px-4 py-8">
             <header className="text-center mb-12">
               <h1 className="text-5xl font-bold text-gray-800 dark:text-white mb-4">

--- a/src/components/filters/FilterSidepanel.tsx
+++ b/src/components/filters/FilterSidepanel.tsx
@@ -87,7 +87,7 @@ export function FilterSidepanel({
                    shadow-xl transform transition-transform duration-300 ease-in-out z-50
                    ${isOpen ? 'translate-x-0' : '-translate-x-full'}
                    lg:relative lg:translate-x-0 lg:shadow-none lg:border-r 
-                   lg:border-gray-200 lg:dark:border-gray-700`}
+                   lg:border-gray-200 lg:dark:border-gray-700 lg:h-full lg:flex lg:flex-col`}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
@@ -116,7 +116,7 @@ export function FilterSidepanel({
         </div>
 
         {/* Filter controls */}
-        <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex-shrink-0 p-4 border-b border-gray-200 dark:border-gray-700">
           <button
             onClick={resetFilters}
             disabled={!hasActiveFilters()}
@@ -131,7 +131,7 @@ export function FilterSidepanel({
         </div>
 
         {/* Filter sections */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 min-h-0 overflow-y-auto">
           <div className="p-4 space-y-6">
             {/* Section navigation */}
             <div className="flex flex-wrap gap-2">
@@ -189,7 +189,7 @@ export function FilterSidepanel({
 
         {/* Active filters summary */}
         {hasActiveFilters() && (
-          <div className="p-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+          <div className="flex-shrink-0 p-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
             <h4 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
               Active Filters:
             </h4>


### PR DESCRIPTION
## Summary

Fixes the FilterSidepanel height layout issue where the sidepanel was not filling the complete viewport height on desktop, leaving a visible gap at the bottom.

## Changes Made

### Layout Structure Updates
- **Main layout container**: Changed from `min-h-screen` to `h-screen` to establish proper viewport height context
- **Flex container**: Added `h-full` to propagate height constraints to child components
- **Main content area**: Added `overflow-y-auto` to enable proper scrolling behavior

### Sidepanel Component Improvements  
- **Desktop layout**: Added `lg:h-full lg:flex lg:flex-col` to ensure full height and proper flex structure
- **Header/controls sections**: Added `flex-shrink-0` to prevent compression
- **Scrollable content area**: Added `min-h-0` to enable proper flex shrinking and scrolling
- **Footer section**: Ensured proper positioning with `flex-shrink-0`

### Mobile Behavior Preserved
- Fixed positioning and overlay behavior remain unchanged
- Transition animations and responsive breakpoints maintained
- No breaking changes to mobile user experience

## Technical Details

**Files Modified:**
- `src/app/page.tsx`: Main layout height context fixes
- `src/components/filters/FilterSidepanel.tsx`: Sidepanel height and flex behavior improvements

**Key CSS Changes:**
- `min-h-screen` → `h-screen` (root container)
- Added `h-full` to flex container  
- Added `lg:h-full lg:flex lg:flex-col` to sidepanel
- Added `overflow-y-auto` to main content area
- Added `flex-shrink-0` and `min-h-0` for proper flex behavior

## Testing

- ✅ Build passes successfully
- ✅ ESLint shows no warnings or errors  
- ✅ Dev server starts without issues
- ✅ Mobile behavior preserved (fixed positioning)
- ✅ Desktop layout now fills full viewport height
- ✅ Content scrolling works properly when content exceeds viewport
- ✅ Responsive transitions work smoothly

## Acceptance Criteria Met

- [x] FilterSidepanel fills complete viewport height on desktop (lg+) with no visible gaps
- [x] Mobile overlay behavior remains unchanged and functional
- [x] Scrollable content area works correctly when content exceeds viewport
- [x] No layout shifts or visual glitches during responsive transitions
- [x] Header, filter controls, and footer sections properly positioned
- [x] Active filters summary stays pinned to bottom when present
- [x] Sidepanel background extends seamlessly to bottom of viewport

## Preview

The fix ensures the sidepanel now extends to the full viewport height on desktop screens, eliminating the visual gap that was previously visible at the bottom. The mobile experience remains identical with proper overlay behavior.

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)